### PR TITLE
Crashfix "invalid options '%' to 'format'"

### DIFF
--- a/scripts/rlp_main.lua
+++ b/scripts/rlp_main.lua
@@ -1220,6 +1220,8 @@ function t.TranslateToRussian(message, entity)
 		end
 		--Подстраиваем сообщение под пол персонажа
 		message=(t.ParseTranslationTags(message, ent.prefab, nil, killerkey)) or message
+		--Добавляем записям вида "число%" дополнительный знак % для работы функции string.format
+		message=string.gsub(message, "%d%%", "%1%%")
 		--Подставляем имена, если они есть
 		message=string.format(message, unpack(mentions or {"","","",""}))
 		if entity=="WX78" then


### PR DESCRIPTION
Исправление краша из-за ошибки "_invalid options '%' to 'format'_".

Возникала при наличии знака % во фразе.

Результат после исправления:
![crashfix-percentage](https://github.com/CunningFox146/RLP/assets/80102194/c57634b1-d592-4162-9fcc-cbe80c2b60fb)
